### PR TITLE
fix: iOS 18+ contacts permissions include .limited

### DIFF
--- a/Pendulum/Data/PenPal+Extensions.swift
+++ b/Pendulum/Data/PenPal+Extensions.swift
@@ -366,7 +366,7 @@ extension PenPal {
         
         appLogger.debug("Syncing \(self.wrappedName) with contacts")
         
-        if CNContactStore.authorizationStatus(for: .contacts) == .authorized && !UserDefaults.shared.stopAskingAboutContacts {
+        if CNContactStore.canReadContacts(CNContactStore.authorizationStatus(for: .contacts)) && !UserDefaults.shared.stopAskingAboutContacts {
             
             appLogger.debug("Authorisation")
             

--- a/Pendulum/Extensions/CNContact.swift
+++ b/Pendulum/Extensions/CNContact.swift
@@ -42,6 +42,16 @@ extension CNContact {
     
 }
 
+extension CNContactStore {
+    static func canReadContacts(_ status: CNAuthorizationStatus) -> Bool {
+        if #available(iOS 18, *) {
+            return status == .authorized || status == .limited
+        } else {
+            return status == .authorized
+        }
+    }
+}
+
 #if DEBUG
 extension CNContact {
     static func create(

--- a/Pendulum/Views/PenPalSplitView.swift
+++ b/Pendulum/Views/PenPalSplitView.swift
@@ -84,7 +84,7 @@ struct PenPalSplitView: View {
                         appLogger.debug("Destination appeared!")
                     }
                 } else {
-                    if contactsAccessStatus != .authorized && allPenPals.isEmpty {
+                    if CNContactStore.canReadContacts(contactsAccessStatus) && allPenPals.isEmpty {
                         GrantContactsAccessView(contactsAccessStatus: $contactsAccessStatus)
                     } else if allPenPals.isEmpty {
                         AddFirstPenPalView()

--- a/Pendulum/Views/PenPalTab.swift
+++ b/Pendulum/Views/PenPalTab.swift
@@ -35,7 +35,7 @@ struct PenPalTab: View {
     var body: some View {
         NavigationStack(path: $router.path) {
             Group {
-                if contactsAccessStatus != .authorized && allPenPals.isEmpty {
+                if !CNContactStore.canReadContacts(contactsAccessStatus) && allPenPals.isEmpty {
                     GrantContactsAccessView(contactsAccessStatus: $contactsAccessStatus)
                 } else if allPenPals.isEmpty {
                     AddFirstPenPalView()

--- a/Pendulum/Views/Sheets/AddPenPalSheet.swift
+++ b/Pendulum/Views/Sheets/AddPenPalSheet.swift
@@ -11,6 +11,7 @@ import Contacts
 struct AddPenPalSheet: View {
     
     // MARK: Environment
+    @Environment(\.openURL) private var openURL
     @Environment(\.managedObjectContext) var moc
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject private var router: Router
@@ -55,6 +56,23 @@ struct AddPenPalSheet: View {
         .foregroundColor(.primary)
     }
     
+    @ViewBuilder
+    var limitedContactsLink: some View {
+        if #available(iOS 18, *), contactsAccessStatus == .limited {
+            if let url = UIApplication.systemSettingsURL {
+                Button(action: {
+                    openURL(url)
+                }) {
+                    Text("You previously restricted Pendulum's access to limited contacts. You can choose to add more in ") + Text("Settings.").foregroundColor(.accentColor)
+                }
+                .fullWidth(alignment: .center)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+                .buttonStyle(.plain)
+            }
+        }
+    }
+    
     var body: some View {
         NavigationStack {
             Group {
@@ -86,6 +104,7 @@ struct AddPenPalSheet: View {
                                 }
                             }
                         }
+                        limitedContactsLink
                     }
                     .searchable(text: $searchText)
                 } else {
@@ -108,6 +127,8 @@ struct AddPenPalSheet: View {
                                         Text("Holy prolific writer, Batman!\nYou've added all your contacts as Pen Pals already!")
                                             .fullWidth(alignment: .center)
                                     }
+                                    limitedContactsLink
+                                        .padding(.top, 20)
                                 }
                             } else {
                                 ProgressView()

--- a/Pendulum/Views/Sheets/AddPenPalSheet.swift
+++ b/Pendulum/Views/Sheets/AddPenPalSheet.swift
@@ -91,7 +91,7 @@ struct AddPenPalSheet: View {
                 } else {
                     VStack {
                         Spacer()
-                        if contactsAccessStatus != .authorized {
+                        if !CNContactStore.canReadContacts(contactsAccessStatus) {
                             ContactsAccessRequiredView(contactsAccessStatus: $contactsAccessStatus, alwaysShowImage: true)
                         } else {
                             if contactsFetched {
@@ -135,7 +135,7 @@ struct AddPenPalSheet: View {
                 self.contactsAccessStatus = CNContactStore.authorizationStatus(for: .contacts)
             }
             .task {
-                if self.contactsAccessStatus == .authorized {
+                if CNContactStore.canReadContacts(self.contactsAccessStatus) {
                     let store = CNContactStore()
                     let keys = [
                         CNContactFormatter.descriptorForRequiredKeys(for: .fullName),

--- a/Pendulum/Views/Sheets/PenPalContactSheet.swift
+++ b/Pendulum/Views/Sheets/PenPalContactSheet.swift
@@ -39,7 +39,7 @@ struct PenPalContactSheet: View {
                         TextField("Notes - postage cost, etc", text: $notes, axis: .vertical)
                     }
                     
-                    if contactsAccessStatus != .authorized && !self.stopAskingAboutContacts {
+                    if !CNContactStore.canReadContacts(contactsAccessStatus) && !self.stopAskingAboutContacts {
                         ContactsAccessRequiredView(contactsAccessStatus: $contactsAccessStatus, reason: "to fetch any addresses for \(penpal.wrappedName).")
                             .padding(.top)
                     } else {


### PR DESCRIPTION
Users who only chose to give limited contacts access to Pendulum see unexpected behaviour as the code only checks for the status of .authorized. This commit updates the status to treat .limited access as the same.